### PR TITLE
feat: Reduce long traceback when Redis is down and subscriber threads are dying

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
* Reduce long traceback when Redis is down and subscriber threads are not able to subscribe to the channel, so they are failing and dying later